### PR TITLE
Moving to fixed version 9.2.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,7 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.firebase:firebase-core:9.+'
-    compile 'com.google.firebase:firebase-messaging:9.+'
+    compile 'com.google.firebase:firebase-core:9.2.1'
+    compile 'com.google.firebase:firebase-messaging:9.2.1'
 }
 


### PR DESCRIPTION
This is to fix an issue when compiling using react-native-google-signin, which requires 9.2.1
